### PR TITLE
Enhance hashing for Value types: ensure Interval hashes like Set for …

### DIFF
--- a/evaluator/src/value.rs
+++ b/evaluator/src/value.rs
@@ -78,7 +78,13 @@ impl Ord for Value {
         let other_discr = core::mem::discriminant(other);
 
         if self_discr != other_discr {
-            return std::cmp::Ord::cmp(&self_discr, &other_discr); // Fully qualified cmp
+            // Compare discriminants by their debug string, since Discriminant does not implement Ord
+            use std::fmt::Write;
+            let mut self_dbg = String::new();
+            let mut other_dbg = String::new();
+            write!(&mut self_dbg, "{:?}", self_discr).unwrap();
+            write!(&mut other_dbg, "{:?}", other_discr).unwrap();
+            return self_dbg.cmp(&other_dbg);
         }
 
         match (self, other) {


### PR DESCRIPTION
…consistent map key behavior. Add tests for hash equivalence and map key retrieval using Interval and Set.

<!-- Please ensure that your PR includes the following, as needed -->

- [ ] Tests added for any new code
- [ ] Documentation added for any new functionality
- [ ] Entries added to the respective `CHANGELOG.md` for any new functionality
- [ ] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
